### PR TITLE
feat: ingest July 2026 backlog note submissions (42 hand notes)

### DIFF
--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/bce/topics/partABce.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/bce/topics/partABce.js
@@ -3,7 +3,8 @@ let textBlockGen = require("../../../../../../../genrators/textBlockGen");
 
 let partA_bce = [
     textBlockGen(`🔷 Hand Note(Akib+Tripto, 2019)-\n\nhttps://drive.google.com/file/d/1jhi3aPINS9CeTB2SVkrNFGaaL3tPl6KU/view?usp=sharing`),
-    textBlockGen(`🔷 Communication Model -\n\nhttps://drive.google.com/file/d/1IHP63A_0U25kXHZKMy4XKEsd5FXtLwf9/view?usp=sharing`)
+    textBlockGen(`🔷 Communication Model -\n\nhttps://drive.google.com/file/d/1IHP63A_0U25kXHZKMy4XKEsd5FXtLwf9/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1zDzbxLDG-yFHEi2yFGjvai_NBmytNrzt/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1/topics/cehm1Kinetics.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1/topics/cehm1Kinetics.js
@@ -12,6 +12,8 @@ let chem1Kinetics = [
     textBlockGen(`🔷 Hand Note(Suriya,YE-46 ,2021) - \n\nhttps://drive.google.com/file/d/1Rpptn_yR3DWm6pnHvfmfhtRH1wtKapAY/view?usp=sharing`),
     textBlockGen(`🔷 Slide(2019)-\n\nhttps://drive.google.com/file/d/1Tp8K8LazObsV9dVXBOaooXoeelsNoCUz/view?usp=sharing`),
     textBlockGen(`🔷 Sheet(2019)-\n\nhttps://drive.google.com/file/d/1-46QhXpDeEICp0jthkxzMIcD0G9_1Uf8/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1PsCtSH4iJhkEhv3bxnDaR2i9NCvVBpdI/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1KIdug1-UsQRo6QPQsvRJ2bhmm5ttT78x/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1/topics/chem1Acibas.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1/topics/chem1Acibas.js
@@ -10,6 +10,8 @@ let chem1AcidBase = [
     textBlockGen(`🔷 Hand Note(Sagar, WPE-46,2021)- \n\nhttps://drive.google.com/file/d/186ePXA7avjm9atcfABOsbePBS3q6_tbC/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Nihat, YE-46,2020)- \n\nhttps://drive.google.com/file/d/13-8AGLdOT3_1wdvh2rB1oiD5wD5qvXk0/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Nafis, IPE-46,2021)- \n\nhttps://drive.google.com/file/d/11ZngqbAz1c5QmiQY29noh6v-MGxJU94l/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1dHDsBZRJ0NoF7hII6CNzi1RE1cCOyo7N/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1UwHp2awMjw5L0dOMXMt00AWQJmvNryN1/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1/topics/chem1Dilu.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1/topics/chem1Dilu.js
@@ -27,6 +27,9 @@ let chem1Dilu = [
     //textBlockGen(`🔷 Sheet (Amzad Sir, 2018)-\n\nhttps://drive.google.com/file/d/1hPklz_SZUv7VCFs2wbKY22n1Wr-ITch3/view?usp=sharing`),
     textBlockGen(`🔷 Sheet(Brishty Mam, 2019)-\n\nhttps://drive.google.com/file/d/1CZer_BVmqEhDt-YED8B-H-O5cIhN41vN/view?usp=sharing`),
     textBlockGen(`🔷 Book Scanned(2019)-\n\nhttps://drive.google.com/file/d/1_X3pm63slFI3zriqQ5m8xBxHfExYruN1/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1_N8Ygh9MWX2MEODUmo5kuNrd0pt72HUl/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/11vmMp3Up3K2dCLFsjRrd_2GV_LBiGRap/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/10KdEqa7fGAQBPF8cfyg0qgOQk-0tdMqS/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1/topics/chem1Equi.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1/topics/chem1Equi.js
@@ -11,6 +11,8 @@ let chem1Equi = [
     textBlockGen(`🔷 Hand Note(Nihat,YE-46,2021) - \n\nhttps://drive.google.com/file/d/1CsMyBlnuOJfkpVO1oCsZkfBLbEhirtaL/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Akib, 2018) - \n\nhttps://drive.google.com/file/d/1LLdjKRVQxX6_P3G8GA34hQcQTIh55EFJ/view?usp=drivesdk`),
     textBlockGen(`🔷 Hand Note(Oindrela, 2019)-\n\nhttps://drive.google.com/file/d/1e7rU0MYF8Fx_ntsNZNxeULdYNvgX0tLp/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1R_BgeYKKp_dN_KSwsAXSKlf0g3wLcAJY/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1k7MGBDw6k8fbJhEm4Bj84tuiVkSC1_1l/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1/topics/chem1Photo.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1/topics/chem1Photo.js
@@ -12,6 +12,8 @@ let chem1Photo = [
     textBlockGen(`🔷 Hand Note(Nafis, IPE-46,2020)-\n\nhttps://drive.google.com/file/d/1msasoTT1LEDG4w1rkpi4de2GNNpW8AvJ/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Nihat, 46,2021)-\n\nhttps://drive.google.com/file/d/1xtulOxDkVNkFYLKYLb1ZqqmLS8SB12hr/view?usp=sharing`),
    
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1yUfAuGovD49YYPZxkf7KFEQo9Dn4Dc98/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/11O5H3QlNbkJVwEsYGNsTNxLOfpcak8Re/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem2/topics/chem2Carbonyl.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem2/topics/chem2Carbonyl.js
@@ -11,6 +11,8 @@ let chem2Carbonyl = [
     textBlockGen(`🔷 Hand Note(Fahim) -\n\nhttps://drive.google.com/file/d/1SjHUCqqVdzD4c7-mDaYHnvMIZAt2EU9i/view?usp=sharing`),
     textBlockGen(`🔷 Class Lecture(Amjad Sir) -\n\nhttps://drive.google.com/file/d/1c1qhsSVot07WD0iDFWjpdyVK2nGfVTQA/view?usp=sharing`),
     textBlockGen(`🔷 Carbonyl Compounds (Farzana Mam) - \n\nhttps://drive.google.com/file/d/15HGy76IIatx9pD-cbb_B9LTU_cFV9nvK/view?usp=drivesdk`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1ALc892aCLTPyJgOUE8Nc6nzh573eSqHB/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1CoCi9ar0AZmVgA0YAMsc2deV3LFzEfpl/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem2/topics/chem2OrgReac.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem2/topics/chem2OrgReac.js
@@ -12,6 +12,8 @@ let chem2OrgReac = [
     textBlockGen(`🔷 Organic Reaction Mechanism(Book Scanned) - \n\nhttps://drive.google.com/file/d/0B0FdOS_BOGE3ZFN5dlFTVG1OWXM/view?usp=sharing`),    
     textBlockGen(`🔷 Organic Reaction Mechanism(Book Scanned) - \n\nhttps://drive.google.com/file/d/0B0FdOS_BOGE3c0tLS0ZoY08yck0/view?usp=sharing`),    
    
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1x04JcnVRRy_4NPg2mJIeYr8dm3tyIkl9/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1BzkCAtZkNeXu0QTJKMdKg9mLBVcvZklO/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/math1/topics/math1Differnti.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/math1/topics/math1Differnti.js
@@ -16,6 +16,7 @@ let math1Differn = [
     textBlockGen(`🔷 Limit, Continuity & Differentiability (Akib)-\n\nhttps://drive.google.com/file/d/1eQWQQfmhpbLPbl2tfwox-UxZYn5a8HGM/view?usp=drivesdk`),
     textBlockGen(`🔷 Partial Derivative(Akib) - \n\nhttps://drive.google.com/file/d/1-X4pohf1ACsMr_Jt_wMx4iPnIudQWApq/view?usp=drivesdk`),
     textBlockGen(`🔷 Hand Note(Samet,FE-47,2023) - \n\nhttps://drive.google.com/file/d/1Q1iYL_LOWbaVgesJz7Id6YsDWpFzg7nq/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Md Arman Prodhan, WPE-50, 2026) - \n\nhttps://drive.google.com/file/d/1S62-trWIhSchYs1OynFmW5BuYV2GtWO-/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/math2/topics/math2ODe.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/math2/topics/math2ODe.js
@@ -15,6 +15,11 @@ let math2Ode = [
     textBlockGen(`🔷 Hand Note(Sazzad,FE-46,2022)-\n\nhttps://drive.google.com/file/d/1NWfY5bARZts-NyU7DYbeAot2nad_xexd/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Nafis,IPE-46,2022)-\n\nhttps://drive.google.com/file/d/1TzROXr-WxCbQ-isHm37yC22XR8iRUvX6/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Hemul,TFD-45,2021)-\n\nhttps://drive.google.com/file/d/1gKfaEoH3DyypKBJ49O3zqWKYGijl477_/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Tahsin Azad Koli, ESE-51, 2026) - \n\nhttps://drive.google.com/file/d/1cdedmNuRJn4hsUHE5H4sYDuj6y1mCu5Y/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1dCUTW3fND-brnMJqa1ElgP7FRgWrmjlP/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1A6Ir1kuWzcp7CDcZQnpVEJdcVYRdnVss/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/12oVPEf8GVqitEUliBQ0VrwofDD4L387M/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1mj_o1yub38hF1k1tL5ZN1kE7ij7ZXx15/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1/topics/phy1Circular.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1/topics/phy1Circular.js
@@ -11,6 +11,8 @@ let phy1Circular = [
     textBlockGen(`🔷 Hand Note(Akib, 2018) - \n\nhttps://drive.google.com/file/d/1lPLj_asWPh9_q9J5yZ06_tMKSdPO3MH7/view?usp=drivesdk`),
     textBlockGen(`🔷 Hand Note(Sazzad, 2019)- \n\nhttps://drive.google.com/file/d/1Re1sTn7V96we1hxoCCX80eQEM0TiKo-Q/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Tripto, 2018) - \n\nhttps://drive.google.com/file/d/1FiD3RTw8oqpzWL3yxFpKTQbzcsCnpejP/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1m4p6ZJl7aDYxfyQDGO6LorIrNPjMX5Xh/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1odrQqMYCuq7mTymNMWMgwPKGAemgZJv1/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1/topics/phy1Hydro.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1/topics/phy1Hydro.js
@@ -9,7 +9,9 @@ let phy1Hydro = [
     textBlockGen(`🔷 Hand Note(Akib, ,AE-44, 2018) - \n\nhttps://drive.google.com/file/d/1bbfKr4SrSybDdUJXoa2FkPiWZFlPxkNh/view?usp=drivesdk`),
     textBlockGen(`🔷 Hand Note(Sazzad, 2019)-\n\nhttps://drive.google.com/file/d/19Tt9c5xO8bOlT8ckonKYGhFq-dnUbJ_t/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Nafis,IPE-46,2021)-\n\nhttps://drive.google.com/file/d/1jFq1N2aystuQyUYQ1EzlFRRRh0q95Gzk/view?usp=sharing`),
-    textBlockGen(`🔷 Hand Note(Nihat,YE-46,2021)-\n\nhttps://drive.google.com/file/d/1humhZvc7wAr4of6dwJUuah7BlIqlQdq_/view?usp=sharing`)
+    textBlockGen(`🔷 Hand Note(Nihat,YE-46,2021)-\n\nhttps://drive.google.com/file/d/1humhZvc7wAr4of6dwJUuah7BlIqlQdq_/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1kybvAkLINvnE5vVodKPV0C8_e_xizxa5/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1ybTpbjv8vnrcYffzrifRaybxDONRcp-q/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1/topics/phy1Polar.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1/topics/phy1Polar.js
@@ -13,6 +13,9 @@ let phy1Polar = [
     textBlockGen(`🔷 Slide(Tanu Shree Mam, 2019)-\n\nhttps://drive.google.com/file/d/1GIs2TGoW6OrfFJYGACXWEtak8knaj56J/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Prottush,FE-50,2025)-\n\nhttps://drive.google.com/file/d/16gwYXrTqkeKd88lAQsSXDB7Bnc0_6gXi/view?usp=sharing`),
     //textBlockGen(`🔷 Sheet(Zubaer Sir, 2018) - \n\nhttps://drive.google.com/file/d/1P54abtIUDDZr2MD3kqpWKSnupJJLhA-p/view?usp=drivesdk`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1WverOUjBBgtB2_InD5ZKXl03VC7X3pNH/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1uAmxOkgSDtqpfdP0SpATt3WBt2a3yU0C/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/19K_MMQd3h1jWynZTclXozCzkXl3CfOfa/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1/topics/phy1Surface.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1/topics/phy1Surface.js
@@ -12,6 +12,8 @@ let phy1Surface = [
     textBlockGen(`🔷 Hand Note(Uzzal, Affliated, 2020)-\n\nhttps://drive.google.com/file/d/1a9x_pxlpfG3Va4MikAGg-3wCUgG6bZ_I/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Prottush,FE-50,2025)-\n\nhttps://drive.google.com/file/d/1B-HLkbWp5NsQRf7XuvCdVlWWm09-xHxd/view?usp=sharing`),
     
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1_TvJM3i9K5HEneMa4KnqSTmOZ-yKz_Ab/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1_Pk6heVHqCe0pHFgO7HQc1YKVg908CTC/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1/topics/phy1Visco.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1/topics/phy1Visco.js
@@ -8,6 +8,8 @@ let phy1Visco = [
     textBlockGen(`🔷 Hand Note(Azim, TEM-46, 2021) -\n\nhttps://drive.google.com/file/d/1Ov0mzQdX8zrdt5sWCKtMHl8aWNVmiz6a/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Nafis, IPE-46, 2021) -\n\nhttps://drive.google.com/file/d/1WV2YywyGgO2qNjV1YRdWg4xyzNnyFu8c/view?usp=sharing`),
     textBlockGen(`🔷 Book Scanned - \n\nhttps://drive.google.com/file/d/1IL5SmJXrUrMCZxX4GlsdfUSSwFYwfGfl/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/102PBAaWWol__Lj1XeNTXvn7vfHOErV04/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1aMM9VQrY3cpMxbiFmnn_QOb_13rr4nVR/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy2/topics/phy2Entropy.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy2/topics/phy2Entropy.js
@@ -15,6 +15,8 @@ let phy2Entropy = [
     textBlockGen(`🔷 Sheet(Hedayet Sir, 2021)-\n\nhttps://drive.google.com/file/d/1m9JHeyIDP1tDD9Mk9KK5vO-EI93rPex5/view?usp=sharing`),
     textBlockGen(`🔷 Tanusree Mam Lec(BA Group)-\n\nhttps://drive.google.com/file/d/1D0VmbVVBTVSw-jF-7A2DsNyC1xjKn9Gr/view?usp=sharing`),
     textBlockGen(`🔷 Book Scanned (Gias Uddin,2019)-\n\nhttps://drive.google.com/file/d/1H_PBmO6EyxrnKhv1EfSPFF3PdhbIZp8R/view`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1pFTL2tmAE6t9lhxBfgGMZTRIFPdYUAjX/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1Hxd_nEEAMwPj6lU3dAeCH1oxfuQn5ZaC/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy2/topics/phy2Modern.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy2/topics/phy2Modern.js
@@ -15,6 +15,7 @@ let phy2Modern = [
     textBlockGen(`🔷 Hand Note (Khalid Sir)- \n\nhttps://drive.google.com/file/d/1KOzshzwiSKGfwoTyvKntqKBe1V1wE3MX/view?usp=sharing`),
     textBlockGen(`🔷 Sheet(2021) -\n\nhttps://drive.google.com/file/d/1oS7R2gXEBzQI41wi0DEE5g5T8aONBA5m/view?usp=sharing`),
     textBlockGen(`🔷 Maths(2021) -\n\nhttps://drive.google.com/file/d/1umPq4BA2iUDFPrgO-0XvSFXxPknfk3vu/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1RdPrOSMgd-eRxA2gGnPp7Wh8u5TPfXcq/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy2/topics/phy2Thermodynamic.js
+++ b/src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy2/topics/phy2Thermodynamic.js
@@ -13,6 +13,8 @@ let phy2ThermoDynamic = [
     textBlockGen(`🔷 Book Scanned(Physics for Eng)-\n\nhttps://drive.google.com/file/d/153ziD8z5wcAFndMLmqigf4oWLnvp9fCt/view?usp=sharing`),
     textBlockGen(`🔷 Book Scanned(A Text Book of Heat)-\n\nhttps://drive.google.com/file/d/1rJ4TsEfW82rmXsBOEfCAWEbxMrHbrRca/view?usp=sharing`),
     textBlockGen(`🔷 Laws of Thermodynamics - \n\nhttps://drive.google.com/file/d/1-3oVc2VrIXF4pSwkeT1BQDr8hC8sewhK/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1RwA28jooQombdMvlThaSp5AGkeOXqLjj/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Midul Hasan, WPE-51, 2026) - \n\nhttps://drive.google.com/file/d/1QVcaw4PrrGw3N2zDbE0JASbVQihyNZDy/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/fm1/topics/fm1Winding.js
+++ b/src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/fm1/topics/fm1Winding.js
@@ -6,6 +6,7 @@ let fm1Winding = [
     textBlockGen(`🔷 Winding Math(Khalid,2019)-\n\nhttps://drive.google.com/file/d/182VWmzXRIF1fWzd5JxD5t2gZYZDvIe4N/view`),
     textBlockGen(`🔷 More Winding Maths - \n\nhttps://drive.google.com/file/d/10TVDlybdfA-bIVK6vd4ugnse0QxDr2UK/view?usp=sharing`),
     textBlockGen(`🔷 Hand Note(Nihat,YE-46,2022)-\n\nhttps://drive.google.com/file/d/14skuNf9FvmU3zBs4LYe3Nd960QLisPO9/view?usp=sharing`),
+    textBlockGen(`🔷 Hand Note(Anas, WPE-50, 2026) - \n\nhttps://drive.google.com/file/d/1f0yfUn09WABqyyT0nEksdRlOpz-as7Bf/view?usp=sharing`),
 ]
 
 

--- a/src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/fyt/topics/fytNotes.js
+++ b/src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/fyt/topics/fytNotes.js
@@ -7,6 +7,9 @@ let fytNotes = [
     },
     {
         "text": `🔷 Hand Note (Math, Farhana Mam) - \n\nhttps://drive.google.com/file/d/1VBtuL8wvLAK7rEKGby4tYXkI9NhKGplg/view?usp=sharing`
+    },
+    {
+        "text": `🔷 Hand Note(Sinha, FE-Affliated, 2026) - \n\nhttps://drive.google.com/file/d/1xCxkH0NoCXn4orqosJR-y7XUyXYOr8K4/view?usp=sharing`
     }
 ]
 

--- a/src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/mmtf/topics/mmtfNotes.js
+++ b/src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/mmtf/topics/mmtfNotes.js
@@ -6,6 +6,9 @@ let mmtfNotes = [
     {
         "text": `🔷 Short Note -  
         https://drive.google.com/file/d/1S9Xo0M0yHdDkrMgg9z8fMggtlKDQETbi/view?usp=sharing`
+    },
+    {
+        "text": `🔷 Hand Note(Sinha, FE-Affliated, 2026) - \n\nhttps://drive.google.com/file/d/1Xf_p5f0GAG4n7imdpDX_PMyOMN9QjQ5g/view?usp=sharing`
     }
 ]
 

--- a/src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/stat/topics/statNotes.js
+++ b/src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/stat/topics/statNotes.js
@@ -4,6 +4,9 @@ let statNotes = [
     },
     {
         "text": `🔷 Hand Note (BA Group, 2018) - \n\nhttps://drive.google.com/file/d/1KizpZJjQQFZB4h_A_C1rMg9Vz9s7Yf8V/view?usp=sharing`
+    },
+    {
+        "text": `🔷 Hand Note(Sinha, FE-Affliated, 2026) - \n\nhttps://drive.google.com/file/d/1cRLWZ7yBtM7OwRYlQPAySQRJ0P0-xwsO/view?usp=sharing`
     }
 ]
 


### PR DESCRIPTION
Add 42 student-submitted hand-note links across Level 1 & 2 subjects (chemistry-1/2, math-1/2, physics-1/2, BCE, FM-1, FYT, MMTF, Statistics) from processed public form submissions. 30 of 72 rows were flagged for manual review (lab reports, ambiguous subjects/topics, missing topic files).


Claude-Session: https://claude.ai/code/session_015KJVNwkJu9y2EhdBV9KuFo