### PR TITLE
Daily-safe ingest upgrade (classifier map, QB exclusion, auto-PR+Telegram, v2 create)

### DIFF
--- a/.github/scripts/apply-ingest.js
+++ b/.github/scripts/apply-ingest.js
@@ -1,48 +1,77 @@
-// Applies the cloud agent's ingest manifest (.ingest/applied.json) to the DB after its PR
-// merges to main: marks each submission status='pr-opened' and mirrors the note into the v2
-// `notes` table (topicName -> topics.name, deduped by Drive file id). Then blanks the manifest
-// so it does not re-apply. Runs on a GitHub Actions runner (has DB egress the cloud agent lacks).
+// Runs on a GitHub Actions runner AFTER the cloud agent's ingest PR merges to main.
+// Reads .ingest/applied.json and mirrors each applied note into the v2 DB:
+//   - marks the submission status='done'
+//   - resolves (or CREATES) the v2 subject + topic, then inserts the note (dedup by Drive id)
+// Then blanks the manifest so it can't re-apply ([skip ci] on the commit prevents re-trigger).
 //
-// applied.json shape: [{ id, topicName, title, url }]
-// Env: DATABASE_URL. Run by .github/workflows/notebot-apply-ingest.yml
+// applied.json item shape (all optional except id/topicName/url):
+//   { id, level, subjectDir, subjectName, topicName, topicDisplay, title, url }
+//   topicName === v1 topic-file basename === v2 topics.name (the primary key we map on).
+//
+// Env: DATABASE_URL. Runner has DB egress the cloud agent lacks.
 const fs = require("fs");
 const { Client } = require("pg");
 
 const idOf = (u) => { const m = String(u).match(/\/d\/([\w-]+)/); return m ? m[1] : String(u); };
+const slug = (s) => String(s || "").toLowerCase().replace(/[^a-z0-9_]+/g, "").slice(0, 60) || null;
 
 (async () => {
   let applied = [];
   try { applied = JSON.parse(fs.readFileSync(".ingest/applied.json", "utf8")); } catch { applied = []; }
-  if (!Array.isArray(applied) || applied.length === 0) {
-    console.log("applied.json empty — nothing to apply");
-    return;
-  }
+  if (!Array.isArray(applied) || applied.length === 0) { console.log("applied.json empty — nothing to apply"); return; }
+
   const c = new Client({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
   await c.connect();
-  let marked = 0, inserted = 0, dupes = 0;
-  const unmapped = [];
+  let done = 0, inserted = 0, dupes = 0, newTopics = 0, newSubjects = 0;
+  const problems = [];
+
   for (const a of applied) {
     const id = parseInt(a.id, 10);
-    if (Number.isInteger(id)) {
-      await c.query("UPDATE submissions SET status='pr-opened' WHERE id=$1", [id]);
-      marked++;
-    }
+    if (Number.isInteger(id)) { await c.query("UPDATE submissions SET status='done' WHERE id=$1", [id]); done++; }
     if (!a.topicName || !a.url) continue;
-    const t = await c.query("SELECT id FROM topics WHERE name=$1", [a.topicName]);
-    if (t.rows.length !== 1) { unmapped.push(`${a.topicName} (${t.rows.length} matches)`); continue; }
-    const topicId = t.rows[0].id;
-    const existing = (await c.query("SELECT url FROM notes WHERE topic_id=$1", [topicId])).rows;
+
+    // 1) resolve the v2 topic by name (== v1 topic-file basename)
+    let topic = (await c.query("SELECT id FROM topics WHERE name=$1", [a.topicName])).rows[0];
+
+    // 2) create it if missing (the agent created a NEW v1 topic/subject)
+    if (!topic) {
+      const levelSlug = String(a.level || "").trim();
+      const level = (await c.query("SELECT id FROM levels WHERE slug=$1", [levelSlug])).rows[0];
+      if (!level) { problems.push(`${a.topicName}: unknown level '${a.level}'`); continue; }
+
+      // find (or create) the subject: match by slug/name of the v1 subject dir within the level
+      const sKey = slug(a.subjectDir) || slug(a.subjectName);
+      let subject = (await c.query(
+        "SELECT id FROM subjects WHERE level_id=$1 AND (slug=$2 OR name=$2)", [level.id, sKey]
+      )).rows[0];
+      if (!subject) {
+        const sSort = (await c.query("SELECT COALESCE(MAX(sort_order),0)+1 AS n FROM subjects WHERE level_id=$1", [level.id])).rows[0].n;
+        subject = (await c.query(
+          "INSERT INTO subjects (level_id,name,display_name,slug,sort_order,metadata) VALUES ($1,$2,$3,$4,$5,$6) RETURNING id",
+          [level.id, sKey, a.subjectName || a.subjectDir || sKey, sKey, sSort, JSON.stringify({ source: "ingest-auto" })]
+        )).rows[0];
+        newSubjects++;
+      }
+      const tSort = (await c.query("SELECT COALESCE(MAX(sort_order),0)+1 AS n FROM topics WHERE subject_id=$1", [subject.id])).rows[0].n;
+      topic = (await c.query(
+        "INSERT INTO topics (subject_id,name,display_name,slug,sort_order,metadata) VALUES ($1,$2,$3,$4,$5,$6) RETURNING id",
+        [subject.id, a.topicName, a.topicDisplay || a.topicName, slug(a.topicName), tSort, JSON.stringify({ source: "ingest-auto" })]
+      )).rows[0];
+      newTopics++;
+    }
+
+    // 3) insert the note (skip if the same Drive file id is already under this topic)
+    const existing = (await c.query("SELECT url FROM notes WHERE topic_id=$1", [topic.id])).rows;
     if (existing.some((e) => idOf(e.url) === idOf(a.url))) { dupes++; continue; }
-    const mx = (await c.query("SELECT COALESCE(MAX(sort_order),0)+1 AS n FROM notes WHERE topic_id=$1", [topicId])).rows[0].n;
+    const nSort = (await c.query("SELECT COALESCE(MAX(sort_order),0)+1 AS n FROM notes WHERE topic_id=$1", [topic.id])).rows[0].n;
     await c.query(
-      "INSERT INTO notes (topic_id, title, url, sort_order, metadata) VALUES ($1,$2,$3,$4,$5)",
-      [topicId, a.title || "", a.url, mx, JSON.stringify({ source: "ingest-auto" })]
+      "INSERT INTO notes (topic_id,title,url,sort_order,metadata) VALUES ($1,$2,$3,$4,$5)",
+      [topic.id, a.title || "", a.url, nSort, JSON.stringify({ source: "ingest-auto" })]
     );
     inserted++;
   }
   await c.end();
-  console.log(`marked pr-opened:${marked} | v2 inserted:${inserted} | dupes skipped:${dupes} | unmapped:${unmapped.length}`);
-  if (unmapped.length) console.log("  unmapped topicNames (fix manually in v2):", unmapped.join(", "));
-  // blank the manifest so a re-run / re-push does not double-apply
+  console.log(`done:${done} | v2 inserted:${inserted} | dupes:${dupes} | new topics:${newTopics} | new subjects:${newSubjects} | problems:${problems.length}`);
+  if (problems.length) console.log("  problems:", problems.join(" ; "));
   fs.writeFileSync(".ingest/applied.json", "[]\n");
 })().catch((e) => { console.error("apply-ingest failed:", e.message); process.exit(1); });

--- a/.github/scripts/open-pr-notify.js
+++ b/.github/scripts/open-pr-notify.js
@@ -1,0 +1,98 @@
+// Runs on a GitHub Actions runner when the cloud agent pushes an ingest/auto-* branch
+// (the sandbox can't reach api.github.com or Telegram, so the runner does it):
+//   1. builds a PR body = table of applied notes (+ new subjects/topics + flagged list)
+//   2. opens the PR (base main) if one doesn't already exist
+//   3. marks the applied submissions status='pr-open' (dedup: next queue skips them)
+//   4. sends a Telegram message with the PR link + note table
+//
+// Env: GITHUB_TOKEN, GITHUB_REPOSITORY (owner/repo), GITHUB_REF_NAME (branch),
+//      DATABASE_URL, TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID.
+const fs = require("fs");
+const { Client } = require("pg");
+
+const esc = (s) => String(s == null ? "" : s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+const noteName = (t) => { const m = String(t || "").match(/\(([^)]*)\)/); return m ? m[1] : (t || "").replace(/^🔷|^📺/, "").trim(); };
+
+async function main() {
+  const repo = process.env.GITHUB_REPOSITORY;          // TriptoAfsin/notebot-engine-v1
+  const branch = process.env.GITHUB_REF_NAME;           // ingest/auto-YYYY-MM-DD
+  const gh = process.env.GITHUB_TOKEN;
+  const ghHead = { Authorization: `Bearer ${gh}`, Accept: "application/vnd.github+json", "Content-Type": "application/json" };
+
+  let applied = [];
+  try { applied = JSON.parse(fs.readFileSync(".ingest/applied.json", "utf8")); } catch { applied = []; }
+  let flagged = [];
+  try { flagged = JSON.parse(fs.readFileSync(".ingest/flagged.json", "utf8")); } catch { flagged = []; }
+
+  const date = branch.replace("ingest/auto-", "");
+  const newSubs = applied.filter((a) => a.new === "subject");
+  const newTops = applied.filter((a) => a.new === "topic");
+
+  // ---- PR body ----
+  let body = `Automated note ingest for **${date}**.\n\n`;
+  if (applied.length) {
+    body += `### ✅ Applied (${applied.length})\n\n| Note | Placed in | Link |\n|---|---|---|\n`;
+    for (const a of applied) {
+      const where = `L${a.level || "?"} · ${a.subjectName || a.subjectDir || "?"} / ${a.topicDisplay || a.topicName || "?"}` +
+        (a.new ? ` **(new ${a.new})**` : "");
+      body += `| ${noteName(a.title)} | ${where} | [open](${a.url}) |\n`;
+    }
+    body += "\n";
+  } else {
+    body += "_No notes auto-applied this run._\n\n";
+  }
+  if (newSubs.length) body += `> ⚠️ **${newSubs.length} NEW SUBJECT(S)** created — review the chatbot + web-app wiring carefully (see \`.ingest/WIRING.md\`).\n\n`;
+  if (flagged.length) {
+    body += `### 🚩 Flagged / manual (${flagged.length})\n\n| Submission | Reason | Link |\n|---|---|---|\n`;
+    for (const f of flagged) body += `| ${esc(f.name || "")} — ${esc(f.subject_name || "")} / ${esc(f.topic_name || "")} | ${esc(f.reason || f.kind || "")} | [open](${f.public_url || f.url || ""}) |\n`;
+    body += "\n";
+  }
+  body += `\n_On merge, \`apply-ingest\` mirrors these into the v2 notes DB._`;
+
+  // ---- open PR (or find existing) ----
+  let prUrl = "", prNum = 0;
+  const owner = repo.split("/")[0];
+  let r = await fetch(`https://api.github.com/repos/${repo}/pulls`, {
+    method: "POST", headers: ghHead,
+    body: JSON.stringify({ title: `Auto note ingest ${date}`, head: branch, base: "main", body }),
+  });
+  if (r.status === 201) { const j = await r.json(); prUrl = j.html_url; prNum = j.number; }
+  else {
+    // likely already exists — look it up
+    const ex = await (await fetch(`https://api.github.com/repos/${repo}/pulls?head=${owner}:${branch}&state=open`, { headers: ghHead })).json();
+    if (Array.isArray(ex) && ex[0]) { prUrl = ex[0].html_url; prNum = ex[0].number; }
+    else console.log("PR create failed:", r.status, (await r.text()).slice(0, 200));
+  }
+  console.log("PR:", prNum, prUrl);
+
+  // ---- mark applied rows pr-open (dedup) ----
+  const ids = applied.map((a) => parseInt(a.id, 10)).filter(Number.isInteger);
+  if (ids.length && process.env.DATABASE_URL) {
+    const c = new Client({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+    await c.connect();
+    await c.query("UPDATE submissions SET status='pr-open' WHERE id = ANY($1::int[]) AND status='pending'", [ids]);
+    await c.end();
+    console.log("marked pr-open:", ids.length);
+  }
+
+  // ---- Telegram ----
+  const tok = process.env.TELEGRAM_BOT_TOKEN, chat = process.env.TELEGRAM_CHAT_ID;
+  if (tok && chat) {
+    const lines = [
+      "📥 <b>NoteBot ingest PR ready</b>",
+      "------------------",
+      `📝 Applied: <b>${applied.length}</b>${newSubs.length ? ` · new subjects: ${newSubs.length}` : ""}${newTops.length ? ` · new topics: ${newTops.length}` : ""}`,
+      flagged.length ? `🚩 Flagged: <b>${flagged.length}</b>` : null,
+      prUrl ? `🔗 <a href="${prUrl}">PR #${prNum}</a>` : "⚠️ PR not opened (see Action log)",
+    ].filter(Boolean);
+    const preview = applied.slice(0, 8).map((a) => `• ${esc(noteName(a.title))} → ${esc(a.subjectName || a.subjectDir || "")}/${esc(a.topicDisplay || a.topicName || "")}${a.new ? ` (new ${a.new})` : ""}`);
+    if (preview.length) lines.push("", ...preview, applied.length > 8 ? `…and ${applied.length - 8} more` : "");
+    const text = lines.filter((x) => x !== "").join("\n");
+    const tr = await fetch(`https://api.telegram.org/bot${tok}/sendMessage`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chat, text, parse_mode: "HTML", disable_web_page_preview: true }),
+    });
+    console.log("telegram:", tr.status);
+  }
+}
+main().catch((e) => { console.error("open-pr-notify failed:", e.message); process.exit(1); });

--- a/.github/scripts/prepare-queue.js
+++ b/.github/scripts/prepare-queue.js
@@ -13,9 +13,11 @@ const { Client } = require("pg");
     ssl: { rejectUnauthorized: false },
   });
   await c.connect();
+  // kind='question' (QBs) are handled by n8n copying to the QB Drive folder — no code change,
+  // so they are excluded from the ingest queue entirely.
   const r = await c.query(
     "SELECT id, submitted_at, name, batch, department, level, subject_name, topic_name, kind, public_url " +
-    "FROM submissions WHERE status='pending' AND resolve_status='ok' ORDER BY submitted_at"
+    "FROM submissions WHERE status='pending' AND resolve_status='ok' AND kind <> 'question' ORDER BY submitted_at"
   );
   await c.end();
   fs.mkdirSync(".ingest", { recursive: true });

--- a/.github/workflows/mirror-to-gitlab.yml
+++ b/.github/workflows/mirror-to-gitlab.yml
@@ -6,6 +6,8 @@ name: Mirror main to GitLab (deploy)
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - ".ingest/**" # queue/manifest churn shouldn't trigger a GitLab deploy
 
 concurrency:
   group: gitlab-mirror

--- a/.github/workflows/notebot-open-pr.yml
+++ b/.github/workflows/notebot-open-pr.yml
@@ -1,0 +1,35 @@
+name: NoteBot - open PR + notify
+
+# Fires when the cloud ingest agent pushes an ingest/auto-* branch. The agent's sandbox
+# can't reach api.github.com or Telegram, so this runner opens the PR, marks the applied
+# rows pr-open (dedup), and sends the Telegram notification with a note table.
+
+on:
+  push:
+    branches:
+      - "ingest/auto-*"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: notebot-open-pr-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  open:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm install pg@8 --no-save
+      - name: Open PR, mark pr-open, notify Telegram
+        run: node .github/scripts/open-pr-notify.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/.github/workflows/notebot-prepare-queue.yml
+++ b/.github/workflows/notebot-prepare-queue.yml
@@ -6,7 +6,7 @@ name: NoteBot - prepare ingest queue
 
 on:
   schedule:
-    - cron: "30 0 * * 1" # Mondays 00:30 UTC
+    - cron: "30 0 * * *" # daily 00:30 UTC (30 min before the cloud routine)
   workflow_dispatch: {}
 
 permissions:

--- a/.ingest/WIRING.md
+++ b/.ingest/WIRING.md
@@ -1,0 +1,55 @@
+# Ingest wiring rules — READ BEFORE creating subjects/topics
+
+The classifier places notes at three escalating levels of effort/risk. **Always prefer the
+lowest one that fits.** v1 has TWO parallel systems that BOTH need wiring — the Messenger
+chatbot (`chatbotController.js`) and the web app (`appController/appController.js` + `routes/web.js`)
+— plus a keyword system. Skipping a step usually fails **silently** (dead button / 404).
+
+Paths below use: level `L`, subject key `x` (lowercase, e.g. `fme`), topic file `xT`, payload
+strings `x_flow` / `x_T_flow`. Base = `src/controllers/flows/botReplies/note_levels/level_L/level_L_subs/`.
+
+---
+
+## Level 1 — append a note to an EXISTING topic file  (trivial, always safe)
+Append before `module.exports` in `.../x/topics/xT.js`:
+```js
+textBlockGen(`🔷 Hand Note(<name>, <dept>-<batch>, <year>) - \n\n<public_url>`),
+```
+(YouTube → `📺 Video Lecture(...)`.) Nothing else to wire. **This is the default path.**
+
+## Level 2 — new TOPIC under an EXISTING subject  (bounded, ~6 edits)
+1. Create `.../x/topics/xT.js` (array of text blocks + `module.exports`).
+2. `.../x/x_flow.js`: add `payloadBtnGen("T","x_T_flow")` inside a group.
+3. `chatbotController.js`: add `const x_T = require(".../x/topics/xT");` (near other requires) AND a branch in `handlePostback`: `else if (payload === "x_T_flow") { magicFunc(sender_psid, x_T); }` — **payload string must match step 2 exactly**.
+4. `appController/academic/notes/levelL/subs/x/topics/appXT.js`: `module.exports = TextBlockTrans(require(".../x/topics/xT"))`.
+5. `appController/appController.js`: require `appXT`, add handler `let xTFlow=(req,res)=>{...return res.send(xT)}`, add `xTFlow: xTFlow,` to `module.exports`.
+6. `routes/web.js`: `router.get("/app/notes/L/x/x_T_flow", appController.xTFlow);` — **path segment after `/x/` must equal the payload string** (SubTopicTrans builds `route = app/notes/L/x/<payload>`).
+
+## Level 3 — new SUBJECT  (~16 edits, HIGH RISK — flag loudly in the PR)
+Do steps 1–6 above for the subject's first topic, PLUS:
+
+**Chatbot**
+- `.../x/x_flow.js` — the subject flow (grouped `payloadBtnGen`/`webBtnBlockGen`).
+- `level_L_flow.js` — add `payloadBtnGen("X","x_flow")` to a "🔰 Select Subject for level L" group. *(skip → no subject button)*
+- `chatbotController.js` — require `x_flow`; `handlePostback` branch `else if (payload==="x_flow"){ magicFunc(sender_psid, x_flow); }`.
+- keywords: `keywords/academic_words/subjects/xWords.js`; in `chatbotController.js` require it, alias `const x = x_words;` in `handleMessage`, and `else if (wordIs(x, received_message)) { magicFunc(sender_psid, x_flow); }`. *(skip → not reachable by typing; not fatal)*
+
+**Web app**
+- `appController/academic/notes/levelL/subs/x/x.js` — `module.exports = SubTopicTrans("app/notes/L/x", require(".../x/x_flow"))`.
+- `appController.js` — require `x.js` as `xAppFlow`, handler `let xFlow=(req,res)=>{...return res.send(xAppFlow)}`, export `xFlow: xFlow,`.
+- `routes/web.js` — `router.get("/app/notes/L/x", appController.xFlow);`.
+- `appController/academic/notes/levelL/levelLSubs.js` — append `{ subName:"X", route:"app/notes/L/x" }`. **MANUAL, not auto-generated** *(skip → subject invisible on web app)*.
+
+**Labs (only if the submission is a lab report):** parallel structure under `appController/academic/labReport/levelL/subs/x/` + `router.get("/app/labs/L/x", ...)`.
+
+---
+
+### Silent-break checklist (verify before finishing)
+- [ ] every `payloadBtnGen(...,"P")` has a `handlePostback` branch `payload === "P"`
+- [ ] every such `P` also has a `web.js` route `.../x/P`
+- [ ] new subject added to BOTH `level_L_flow.js` (chatbot) AND `levelLSubs.js` (web)
+- [ ] every edited `.js` passes `node -e "require('./<file>')"`
+- [ ] `require` paths' `../` depth is correct (deep nesting under appController)
+
+Generators live in `src/controllers/genrators/` (historical typo — do NOT rename).
+When you create a subject/topic, also add its aliases to `.ingest/subject-map.json`.

--- a/.ingest/subject-map.json
+++ b/.ingest/subject-map.json
@@ -1,0 +1,1215 @@
+{
+  "note": "Maps submission subject/topic -> v1 subject dir + topic file. Classifier reads this and APPENDS new aliases/subjects/topics as it creates them. dir codes are lowercase; topics are file basenames (no .js). To add a note, append a textBlockGen line to <dir>/topics/<topicFile>.js.",
+  "levels": {
+    "1": {
+      "bce": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/bce",
+        "flow": "bce_flow.js",
+        "topics": [
+          "allsheetsBce",
+          "bceQuestions",
+          "communicationBce",
+          "fullabpartBce",
+          "introBce",
+          "langFuncBce",
+          "letterBce",
+          "partABce",
+          "partBBce",
+          "reading_writingBce",
+          "reportBce"
+        ],
+        "aliases": [
+          "bce"
+        ]
+      },
+      "bfs": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/bfs",
+        "flow": "bfs_flow.js",
+        "topics": [
+          "bfsLec3"
+        ],
+        "aliases": [
+          "bfs"
+        ]
+      },
+      "chem1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem1",
+        "flow": "chem1_flow.js",
+        "topics": [
+          "cehm1Bond",
+          "cehm1Kinetics",
+          "chem1Acibas",
+          "chem1Analy",
+          "chem1Books",
+          "chem1Coll",
+          "chem1Complx",
+          "chem1Dilu",
+          "chem1Equi",
+          "chem1Perio",
+          "chem1Photo",
+          "chem1Ques"
+        ],
+        "aliases": [
+          "chem1"
+        ]
+      },
+      "chem2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/chem2",
+        "flow": "chem2_flow.js",
+        "topics": [
+          "chem2AlcPhe",
+          "chem2Amine",
+          "chem2Amino",
+          "chem2Books",
+          "chem2CarboHy",
+          "chem2Carbonyl",
+          "chem2Carboxylic",
+          "chem2ColorDye",
+          "chem2OrgMet",
+          "chem2OrgReac",
+          "chem2Ques",
+          "chem2Solubility"
+        ],
+        "aliases": [
+          "chem2"
+        ]
+      },
+      "cp": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/cp",
+        "flow": "cp_flow.js",
+        "topics": [
+          "arrayCp",
+          "booksCp",
+          "conditionCp",
+          "funcCp",
+          "fundamentalCp",
+          "loopCp",
+          "quesCp",
+          "stringCp",
+          "suggestionCp"
+        ],
+        "aliases": [
+          "cp"
+        ]
+      },
+      "ecb": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/ecb",
+        "flow": "ecb_flow.js",
+        "topics": [
+          "ecbHandNote",
+          "ecbIntro"
+        ],
+        "aliases": [
+          "ecb"
+        ]
+      },
+      "em": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/em",
+        "flow": "em_flow.js",
+        "topics": [
+          "emAlloy",
+          "emAtomicStruct",
+          "emBlastFur",
+          "emBooks",
+          "emCeramic",
+          "emComposites",
+          "emCorrosion",
+          "emCrystal",
+          "emGlass",
+          "emHeattreat",
+          "emIron",
+          "emMath",
+          "emPhaseDiag",
+          "emPlastic",
+          "emQuestions",
+          "emWroughtCast"
+        ],
+        "aliases": [
+          "em"
+        ]
+      },
+      "fh": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/fh",
+        "flow": "fh_flow.js",
+        "topics": [
+          "fhArtDes",
+          "fhEgypt",
+          "fhEliza",
+          "fhGeorgi",
+          "fhGreek",
+          "fhHandloom",
+          "fhJeansHis",
+          "fhMuslin",
+          "fhRenais",
+          "fhRoman",
+          "fhSilk"
+        ],
+        "aliases": [
+          "fh"
+        ]
+      },
+      "fmg": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/fmg",
+        "flow": "fmg_flow.js",
+        "topics": [],
+        "aliases": [
+          "fmg"
+        ]
+      },
+      "iae": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/iae",
+        "flow": "iae_flow.js",
+        "topics": [
+          "iaeBooks",
+          "iaeBrands",
+          "iaeCam",
+          "iaeDiffWoven",
+          "iaeFullSlide",
+          "iaeIntro",
+          "iaeQues",
+          "iaeQuota",
+          "iaeShirt"
+        ],
+        "aliases": [
+          "iae"
+        ]
+      },
+      "iee": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/iee",
+        "flow": "iee_flow.js",
+        "topics": [
+          "ieeBooks",
+          "ieeEnvIssues",
+          "ieeHandNotes",
+          "ieeManEnv",
+          "ieeNatureEnv",
+          "ieeSheets",
+          "ieeSoil",
+          "ieeSPF"
+        ],
+        "aliases": [
+          "iee"
+        ]
+      },
+      "math1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/math1",
+        "flow": "math1_flow.js",
+        "topics": [
+          "math1Axes",
+          "math1Books",
+          "math1Conics",
+          "math1Conver",
+          "math1CoOrd",
+          "math1Differnti",
+          "math1Exapnasion",
+          "math1Extremea",
+          "math1Integreation",
+          "math1Linear",
+          "math1Matrix",
+          "math1Ques",
+          "math1Vector"
+        ],
+        "aliases": [
+          "math1"
+        ]
+      },
+      "math2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/math2",
+        "flow": "math2_flow.js",
+        "topics": [
+          "math2AnnalyFunc",
+          "math2Books",
+          "math2CxNum",
+          "math2Exact",
+          "math2Homo",
+          "math2Laplace",
+          "math2LDE",
+          "math2LinearEqn",
+          "math2LineInt",
+          "math2MethodVar",
+          "math2Moivre",
+          "math2ODe",
+          "math2Ques",
+          "math2RedHomo",
+          "math2Residue",
+          "math2Separ",
+          "math2Sugg",
+          "math2Vector"
+        ],
+        "aliases": [
+          "math2"
+        ]
+      },
+      "ntf": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/ntf",
+        "flow": "ntf_flow.js",
+        "topics": [
+          "ntfAsbestos",
+          "ntfBooks",
+          "ntfFlax",
+          "ntfHandNotes",
+          "ntfHemp",
+          "ntfIntro",
+          "ntfJute",
+          "ntfKapok",
+          "ntfOtherFibres",
+          "ntfPalf",
+          "ntfQues",
+          "ntfSilk",
+          "ntfSisal",
+          "ntfSuggestion"
+        ],
+        "aliases": [
+          "ntf"
+        ]
+      },
+      "phy1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy1",
+        "flow": "phy1_flow.js",
+        "topics": [
+          "phy1Books",
+          "phy1Circular",
+          "phy1Diffrac",
+          "phy1Elasti",
+          "phy1Hydro",
+          "phy1Interfe",
+          "phy1Polar",
+          "phy1Ques",
+          "phy1Surface",
+          "phy1Visco"
+        ],
+        "aliases": [
+          "phy1"
+        ]
+      },
+      "phy2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/phy2",
+        "flow": "phy2_flow.js",
+        "topics": [
+          "phy2Books",
+          "phy2Entropy",
+          "phy2Kinetic",
+          "phy2Magnet",
+          "phy2Modern",
+          "phy2Ques",
+          "phy2Radiation",
+          "phy2Thermodynamic"
+        ],
+        "aliases": [
+          "phy2"
+        ]
+      },
+      "pse": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/pse",
+        "flow": "pse_flow.js",
+        "topics": [
+          "pseAppliPoly",
+          "pseBooks",
+          "pseChainGrowth",
+          "pseChemical",
+          "pseDegradation",
+          "pseFiberForming",
+          "pseHandNotes",
+          "pseIntro",
+          "pseMoleWeight",
+          "pseMorpho",
+          "psePhysical",
+          "psePolymerizationTech",
+          "pseQuestions",
+          "pseStepGrowth",
+          "pseThermalTran"
+        ],
+        "aliases": [
+          "pse"
+        ]
+      },
+      "qb_1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/qb_1",
+        "flow": "qb_1_flow.js",
+        "topics": [],
+        "aliases": [
+          "qb_1"
+        ]
+      },
+      "tmm": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/tmm",
+        "flow": "tmm_flow.js",
+        "topics": [
+          "tmmQues"
+        ],
+        "aliases": [
+          "tmm"
+        ]
+      },
+      "tpm": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_1/level_1_subs/tpm",
+        "flow": "tpm_flow.js",
+        "topics": [
+          "tpmQues",
+          "tpmWovFabManu",
+          "tpmWovFabWet"
+        ],
+        "aliases": [
+          "tpm"
+        ]
+      }
+    },
+    "2": {
+      "am1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/am1",
+        "flow": "am1_flow.js",
+        "topics": [
+          "am1Books",
+          "am1FabricCut",
+          "am1Inspection",
+          "am1Interlining",
+          "am1Intro",
+          "am1Marker",
+          "am1Notes",
+          "am1Pattern",
+          "am1Ques",
+          "am1Seam",
+          "am1Sizing",
+          "am1Spread",
+          "am1Structure",
+          "am1Trim"
+        ],
+        "aliases": [
+          "am1"
+        ]
+      },
+      "ap1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/ap1",
+        "flow": "ap1_flow.js",
+        "topics": [
+          "ap1Books",
+          "ap1FabricCut",
+          "ap1FabricSpreading",
+          "ap1Interlining",
+          "ap1MarkerMaking",
+          "ap1PatternMaking",
+          "ap1Ques",
+          "ap1SewingTherad",
+          "ap1Sizing",
+          "ap1Trim"
+        ],
+        "aliases": [
+          "ap1"
+        ]
+      },
+      "ctca": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/ctca",
+        "flow": "ctca_flow.js",
+        "topics": [
+          "ctcaBleach",
+          "ctcaBooks",
+          "ctcaColloid",
+          "ctcaSheets",
+          "ctcaSolutions",
+          "ctcaSurfactant",
+          "ctcaThickAgent",
+          "ctcaWater"
+        ],
+        "aliases": [
+          "ctca"
+        ]
+      },
+      "eee": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/eee",
+        "flow": "eee_flow.js",
+        "topics": [
+          "eeeBooks",
+          "eeeCh1",
+          "eeeCh2",
+          "eeeCh3",
+          "eeeCh4",
+          "eeeCh5",
+          "eeeCh8",
+          "eeeCircuit",
+          "eeeNotes",
+          "eeeQues",
+          "eeeRms",
+          "eeeWye"
+        ],
+        "aliases": [
+          "eee"
+        ]
+      },
+      "fd2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/fd2",
+        "flow": "fd2_flow.js",
+        "topics": [],
+        "aliases": [
+          "fd2"
+        ]
+      },
+      "fdce": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/fdce",
+        "flow": "fdce_flow.js",
+        "topics": [
+          "fdceBalancingChem",
+          "fdceChromato",
+          "fdceDyesPig",
+          "fdceFiltrationMethod",
+          "fdcePolarity",
+          "fdceSeparationPuri"
+        ],
+        "aliases": [
+          "fdce"
+        ]
+      },
+      "fm1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/fm1",
+        "flow": "fm1_flow.js",
+        "topics": [
+          "fm1Beatup",
+          "fm1Books",
+          "fm1Denim",
+          "fm1Dobby",
+          "fm1HandNotes",
+          "fm1Intro",
+          "fm1Jacquard",
+          "fm1Letoff",
+          "fm1Loom",
+          "fm1MotionWeav",
+          "fm1Picking",
+          "fm1Ques",
+          "fm1Selvedge",
+          "fm1Shedding",
+          "fm1Sizing",
+          "fm1StopMotion",
+          "fm1Sugg",
+          "fm1Takeup",
+          "fm1Tappet",
+          "fm1Warping",
+          "fm1Weav",
+          "fm1Winding"
+        ],
+        "aliases": [
+          "fm1"
+        ]
+      },
+      "fme": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/fme",
+        "flow": "fme_flow.js",
+        "topics": [
+          "fmeBeam",
+          "fmeBelt",
+          "fmeBoiler",
+          "fmeBooks",
+          "fmeCentroid",
+          "fmeColumn",
+          "fmeEnergProc",
+          "fmeEngineCombus",
+          "fmeEnginePetrol",
+          "fmeFluidMech",
+          "fmeGearTrain",
+          "fmeMomentInnertia",
+          "fmeNotes",
+          "fmePowerRef",
+          "fmePump",
+          "fmeQues",
+          "fmeSolid",
+          "fmeSteamTurb",
+          "fmeStress",
+          "fmeSugg",
+          "fmeThermalEng"
+        ],
+        "aliases": [
+          "fme"
+        ]
+      },
+      "fyt": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/fyt",
+        "flow": "fyt_flow.js",
+        "topics": [
+          "fytAfis",
+          "fytBooks",
+          "fytcapaOptical",
+          "fytCounting",
+          "fytEvenness",
+          "fytIso",
+          "fytNotes",
+          "fytNumbering",
+          "fytSugg",
+          "fytTwist"
+        ],
+        "aliases": [
+          "fyt"
+        ]
+      },
+      "idcc": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/idcc",
+        "flow": "idcc_flow.js",
+        "topics": [],
+        "aliases": [
+          "idcc"
+        ]
+      },
+      "marketing": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/marketing",
+        "flow": "marketing_flow.js",
+        "topics": [
+          "marketAdvert",
+          "marketBooks",
+          "marketBranding",
+          "marketChannelDist",
+          "marketCompetetive",
+          "marketConcept",
+          "marketConsumerBuyer",
+          "marketDiffPos",
+          "marketField",
+          "marketFunc",
+          "marketingConsumer",
+          "marketIntro",
+          "marketMacroEnv",
+          "marketMajorPrice",
+          "marketMicroEnv",
+          "marketNewProduct",
+          "marketNotes",
+          "marketOrientation",
+          "marketPrice",
+          "marketPriceStart",
+          "marketQues",
+          "marketRetailing",
+          "marketSegment",
+          "marketSugg",
+          "marketTargeting"
+        ],
+        "aliases": [
+          "marketing"
+        ]
+      },
+      "mmtf": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/mmtf",
+        "flow": "mmtf_flow.js",
+        "topics": [
+          "mmtfAcetate",
+          "mmtfAcrylic",
+          "mmtfBioFib",
+          "mmtfBooks",
+          "mmtfCarbonFib",
+          "mmtfElastomer",
+          "mmtfGlassFib",
+          "mmtfHighPerf",
+          "mmtfIntro",
+          "mmtfLyocell",
+          "mmtfModal",
+          "mmtfNotes",
+          "mmtfNylon",
+          "mmtfPolyamaide",
+          "mmtfPolyester",
+          "mmtfPolyolefin",
+          "mmtfRayon",
+          "mmtfRegen",
+          "mmtfSpinningSys",
+          "mmtfSuggestion",
+          "mmtfVectran"
+        ],
+        "aliases": [
+          "mmtf"
+        ]
+      },
+      "mp": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/mp",
+        "flow": "mp_flow.js",
+        "topics": [
+          "mpCasting",
+          "mpCastingVideo",
+          "mpCeramics",
+          "mpDefects",
+          "mpEDM",
+          "mphotCold",
+          "mpLathe",
+          "mpMCEconomics",
+          "mpMilling",
+          "mpNonConv",
+          "mpPlastic",
+          "mpShapermc",
+          "mpSlideways",
+          "mpWelding"
+        ],
+        "aliases": [
+          "mp"
+        ]
+      },
+      "qb_2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/qb_2",
+        "flow": "qb_2_flow.js",
+        "topics": [],
+        "aliases": [
+          "qb_2"
+        ]
+      },
+      "sss1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/sss1",
+        "flow": "sss1_flow.js",
+        "topics": [
+          "sss1BlowRoom",
+          "sss1Books",
+          "sss1Carding",
+          "sss1DrawFrame",
+          "sss1Intro",
+          "sss1IntroFib"
+        ],
+        "aliases": [
+          "sss1"
+        ]
+      },
+      "sss2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/sss2",
+        "flow": "sss2_flow.js",
+        "topics": [
+          "sss2Notes",
+          "sss2Ringframe"
+        ],
+        "aliases": [
+          "sss2"
+        ]
+      },
+      "stat": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/stat",
+        "flow": "stat_flow.js",
+        "topics": [
+          "statBinomial",
+          "statBooks",
+          "statCentralTend",
+          "statCv",
+          "statDesignExp",
+          "statIntro",
+          "statMoments",
+          "statNormalDistri",
+          "statNotes",
+          "statPoission",
+          "statProbab",
+          "statRegression",
+          "statShape"
+        ],
+        "aliases": [
+          "stat"
+        ]
+      },
+      "tp": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/tp",
+        "flow": "tp_flow.js",
+        "topics": [
+          "tpBooks",
+          "tpFabgeometry",
+          "tpfibMigration",
+          "tpFibreDraw",
+          "tpFriction",
+          "tpNotes",
+          "tpOptical",
+          "tpQues",
+          "tpSugg",
+          "tpSwelling",
+          "tpTensileProp",
+          "tpThermalProp",
+          "tpXray",
+          "tpYarnJamming",
+          "tpYarnStruc"
+        ],
+        "aliases": [
+          "tp"
+        ]
+      },
+      "ttqc": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/ttqc",
+        "flow": "ttqc_flow.js",
+        "topics": [
+          "ttqcAfis",
+          "ttqcBooks",
+          "ttqcCount",
+          "ttqcCrimp",
+          "ttqcFibreProp",
+          "ttqcHvi",
+          "ttqcIntro",
+          "ttqcMoisture",
+          "ttqcNeps",
+          "ttqcNotes",
+          "ttqcSampling",
+          "ttqcTwist"
+        ],
+        "aliases": [
+          "ttqc"
+        ]
+      },
+      "weaving_prep": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/weaving_prep",
+        "flow": "weaving_prep_flow.js",
+        "topics": [
+          "weavBooks"
+        ],
+        "aliases": [
+          "weaving_prep"
+        ]
+      },
+      "wp1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/wp1",
+        "flow": "wp1_flow.js",
+        "topics": [
+          "wp1AcidDye",
+          "wp1BasicDye",
+          "wp1Bleaching",
+          "wp1Books",
+          "wp1ColorFastness",
+          "wp1ColorTest",
+          "wp1Desizing",
+          "wp1DirectDye",
+          "wp1DisperseDye",
+          "wp1DyeingFault",
+          "wp1FoldingTest",
+          "wp1GeneralConcepts",
+          "wp1Intro",
+          "wp1IntroDye",
+          "wp1JiggerMachine",
+          "wp1KierBoiler",
+          "wp1Notes",
+          "wp1Pigment",
+          "wp1Questions",
+          "wp1ReactiveDye",
+          "wp1Scouring",
+          "wp1Singeing",
+          "wp1Stripping",
+          "wp1TexFinishing",
+          "wp1VatDye",
+          "wp1WashingMachine",
+          "wp1Water"
+        ],
+        "aliases": [
+          "wp1"
+        ]
+      },
+      "wpp": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/wpp",
+        "flow": "wpp_flow.js",
+        "topics": [
+          "wppBioScouring",
+          "wppDesizing",
+          "wppImpurities",
+          "wppPretreatment",
+          "wppQues",
+          "wppSingeing"
+        ],
+        "aliases": [
+          "wpp"
+        ]
+      },
+      "ym1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_2/level_2_subs/ym1",
+        "flow": "ym1_flow.js",
+        "topics": [
+          "ym1Blowroom",
+          "ym1Carding",
+          "ym1Comber",
+          "ym1Drawframe",
+          "ym1FibreProp",
+          "ym1Indeterminer",
+          "ym1Intro",
+          "ym1LapFormer",
+          "ym1MixBlend",
+          "ym1RingFrame",
+          "ym1SpeedFrame",
+          "ym1Winding",
+          "ym1YarnCond"
+        ],
+        "aliases": [
+          "ym1"
+        ]
+      }
+    },
+    "3": {
+      "ace": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/ace",
+        "flow": "ace_flow.js",
+        "topics": [
+          "aceActuator",
+          "aceBooks",
+          "aceGrips",
+          "aceHydraulics",
+          "aceIntroControlSys",
+          "aceIntroRobot",
+          "aceJoints",
+          "aceLogicGates",
+          "aceModleingFreq",
+          "aceNumberSysPLC",
+          "acePneumatic",
+          "aceSensors",
+          "aceStructElements",
+          "aceTimeResponse",
+          "aceTransferFunc"
+        ],
+        "aliases": [
+          "ace"
+        ]
+      },
+      "acfd": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/acfd",
+        "flow": "acfd_flow.js",
+        "topics": [],
+        "aliases": [
+          "acfd"
+        ]
+      },
+      "acm": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/acm",
+        "flow": "acm_flow.js",
+        "topics": [
+          "acmAccForMerchendizing",
+          "acmAccountingAction",
+          "acmBooks",
+          "acmCostAccountingSys",
+          "acmCostBehav",
+          "acmCostingTechn",
+          "acmInterestedUsers",
+          "acmIntroCost",
+          "acmRecordingProcess"
+        ],
+        "aliases": [
+          "acm"
+        ]
+      },
+      "am2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/am2",
+        "flow": "am2_flow.js",
+        "topics": [
+          "am2Books",
+          "am2ClassLecture",
+          "am2CostingExcel",
+          "am2LineBalancing"
+        ],
+        "aliases": [
+          "am2"
+        ]
+      },
+      "ap2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/ap2",
+        "flow": "ap2_flow.js",
+        "topics": [
+          "ap2FoldingPackage",
+          "ap2InspectionQuality",
+          "ap2LockStitch",
+          "ap2Pressing",
+          "ap2Stitch"
+        ],
+        "aliases": [
+          "ap2"
+        ]
+      },
+      "econo": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/econo",
+        "flow": "econo_flow.js",
+        "topics": [
+          "econoBooks",
+          "econoClassLec"
+        ],
+        "aliases": [
+          "econo"
+        ]
+      },
+      "fm2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/fm2",
+        "flow": "fm2_flow.js",
+        "topics": [
+          "fm2BasicWarp",
+          "fm2Books",
+          "fm2ClassLec",
+          "fm2Misc",
+          "fm2Notes"
+        ],
+        "aliases": [
+          "fm2"
+        ]
+      },
+      "fsd": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/fsd",
+        "flow": "fsd_flow.js",
+        "topics": [
+          "fsdBooks",
+          "fsdColorWeave",
+          "fsdFancy",
+          "fsdIntro",
+          "fsdPlainWeave",
+          "fsdSatin",
+          "fsdTwill"
+        ],
+        "aliases": [
+          "fsd"
+        ]
+      },
+      "im": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/im",
+        "flow": "im_flow.js",
+        "topics": [
+          "imIndusMange",
+          "imLec1",
+          "imLec2",
+          "imLec3",
+          "imLec4",
+          "imMangeFunc",
+          "imMarket",
+          "imMarketMix",
+          "imNatureScope",
+          "imProdMange",
+          "imProjectFeasa",
+          "imTechMange"
+        ],
+        "aliases": [
+          "im"
+        ]
+      },
+      "knit1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/knit1",
+        "flow": "knit_flow.js",
+        "topics": [
+          "knitLec"
+        ],
+        "aliases": [
+          "knit1"
+        ]
+      },
+      "lss": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/lss",
+        "flow": "lss_flow.js",
+        "topics": [
+          "lssDrawframe",
+          "lssSpreader"
+        ],
+        "aliases": [
+          "lss"
+        ]
+      },
+      "mic": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/mic",
+        "flow": "mic_flow.js",
+        "topics": [
+          "micAngularMeas",
+          "micBooks",
+          "micCh1",
+          "micCh2",
+          "micCh4",
+          "micCH5",
+          "micFatigueFail",
+          "micGearMeas",
+          "micLimitFits",
+          "micLinearMeas",
+          "micNonDestructiveTesting",
+          "micSurfaceFinish",
+          "micThreadMeas"
+        ],
+        "aliases": [
+          "mic"
+        ]
+      },
+      "mpp": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/mpp",
+        "flow": null,
+        "topics": [],
+        "aliases": [
+          "mpp"
+        ]
+      },
+      "om": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/om",
+        "flow": "om_flow.js",
+        "topics": [
+          "ch1OmFlow",
+          "ch2OMFlow",
+          "ch3OMFlow"
+        ],
+        "aliases": [
+          "om"
+        ]
+      },
+      "pcs": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/pcs",
+        "flow": "pcs_flow.js",
+        "topics": [
+          "pcsBooks"
+        ],
+        "aliases": [
+          "pcs"
+        ]
+      },
+      "pd": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/pd",
+        "flow": "pd_flow.js",
+        "topics": [
+          "pdBooks",
+          "pdDesAssembly",
+          "pdDesTension",
+          "pdDFMain",
+          "pdDFManu",
+          "pdDFR",
+          "pdFast",
+          "pdIntro",
+          "pdLoadStress",
+          "pdPlanningDesign",
+          "pdQualityFunc",
+          "pdUnderstandingCustomer"
+        ],
+        "aliases": [
+          "pd"
+        ]
+      },
+      "qb_3": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/qb_3",
+        "flow": "qb_3_flow.js",
+        "topics": [],
+        "aliases": [
+          "qb_3"
+        ]
+      },
+      "tc1": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/tc1",
+        "flow": "tc1_flow.js",
+        "topics": [],
+        "aliases": [
+          "tc1"
+        ]
+      },
+      "tcp": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/tcp",
+        "flow": "tcp_flow.js",
+        "topics": [
+          "tcpKpc"
+        ],
+        "aliases": [
+          "tcp"
+        ]
+      },
+      "tqm": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/tqm",
+        "flow": "tqm_flow.js",
+        "topics": [
+          "tqmContinuousImprove",
+          "tqmControlManage",
+          "tqmIntro",
+          "tqmManageAppro",
+          "tqmQcTools",
+          "tqmQualityReliability",
+          "tqmQualityStd",
+          "tqmTotalQm"
+        ],
+        "aliases": [
+          "tqm"
+        ]
+      },
+      "ttm": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/ttm",
+        "flow": "ttm_flow.js",
+        "topics": [],
+        "aliases": [
+          "ttm"
+        ]
+      },
+      "weaving2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/weaving2",
+        "flow": "weave2_flow.js",
+        "topics": [],
+        "aliases": [
+          "weaving2"
+        ]
+      },
+      "wp2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/wp2",
+        "flow": "wp2_flow.js",
+        "topics": [
+          "wp2Books",
+          "wp2ClassLec"
+        ],
+        "aliases": [
+          "wp2"
+        ]
+      },
+      "ym2": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_3/level_3_subs/ym2",
+        "flow": "ym2_flow.js",
+        "topics": [
+          "ym2Books",
+          "ym2ClassLec",
+          "ym2IntroSpin",
+          "ym2Notes",
+          "ym2Rotor",
+          "ym2SpecialYarns",
+          "ym2Spinning"
+        ],
+        "aliases": [
+          "ym2"
+        ]
+      }
+    },
+    "4": {
+      "bil": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_4/level_4_subs/bil",
+        "flow": "bil_flow.js",
+        "topics": [
+          "bilLaborLaw"
+        ],
+        "aliases": [
+          "bil"
+        ]
+      },
+      "bs": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_4/level_4_subs/bs",
+        "flow": "bs_flow.js",
+        "topics": [],
+        "aliases": [
+          "bs"
+        ]
+      },
+      "epd": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_4/level_4_subs/epd",
+        "flow": "epd_flow.js",
+        "topics": [],
+        "aliases": [
+          "epd"
+        ]
+      },
+      "hrm": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_4/level_4_subs/hrm",
+        "flow": "hrm_flow.js",
+        "topics": [],
+        "aliases": [
+          "hrm"
+        ]
+      },
+      "ir": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_4/level_4_subs/ir",
+        "flow": "ir_flow.js",
+        "topics": [
+          "irIndustrialRelation"
+        ],
+        "aliases": [
+          "ir"
+        ]
+      },
+      "ppc": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_4/level_4_subs/ppc",
+        "flow": "ppc_flow.js",
+        "topics": [],
+        "aliases": [
+          "ppc"
+        ]
+      },
+      "qm": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_4/level_4_subs/qm",
+        "flow": "qm_flow.js",
+        "topics": [],
+        "aliases": [
+          "qm"
+        ]
+      },
+      "tam": {
+        "dir": "src/controllers/flows/botReplies/note_levels/level_4/level_4_subs/tam",
+        "flow": "tam_flow.js",
+        "topics": [
+          "tamIntroMerch"
+        ],
+        "aliases": [
+          "tam"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Upgrades the note-ingestion pipeline for a daily cadence.

- subject-map.json + WIRING.md: deterministic classifier map + full subject/topic wiring checklist (chatbot + web app, with silent-break points).
- prepare-queue: excludes kind=question (QBs are Drive-copy only).
- apply-ingest: on merge, creates missing v2 subjects/topics and inserts notes; marks rows done.
- open-pr-notify + notebot-open-pr.yml: on ingest/auto-* push a runner opens the PR (the cloud sandbox cannot reach api.github.com), posts a note table, marks rows pr-open (daily dedup), and sends Telegram.
- prepare-queue cron -> daily 00:30 UTC.
- mirror-to-gitlab: paths-ignore .ingest/** so queue churn does not deploy.

New repo secrets required: TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID (DATABASE_URL already set).