### PR TITLE
apply-ingest: Telegram v2 rows-added count on merge

### DIFF
--- a/.github/scripts/apply-ingest.js
+++ b/.github/scripts/apply-ingest.js
@@ -73,5 +73,26 @@ const slug = (s) => String(s || "").toLowerCase().replace(/[^a-z0-9_]+/g, "").sl
   await c.end();
   console.log(`done:${done} | v2 inserted:${inserted} | dupes:${dupes} | new topics:${newTopics} | new subjects:${newSubjects} | problems:${problems.length}`);
   if (problems.length) console.log("  problems:", problems.join(" ; "));
+
+  // Telegram: report how many rows landed in the v2 DB on merge
+  const tok = process.env.TELEGRAM_BOT_TOKEN, chat = process.env.TELEGRAM_CHAT_ID;
+  if (tok && chat) {
+    const lines = [
+      "✅ <b>NoteBot v2 sync (merged)</b>",
+      "------------------",
+      `🗄️ Notes added to v2 DB: <b>${inserted}</b>`,
+      (newTopics || newSubjects) ? `🆕 new topics: ${newTopics} · new subjects: ${newSubjects}` : null,
+      dupes ? `♻️ already present: ${dupes}` : null,
+      problems.length ? `⚠️ problems: ${problems.length}` : null,
+    ].filter(Boolean);
+    try {
+      const r = await fetch(`https://api.telegram.org/bot${tok}/sendMessage`, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: chat, text: lines.join("\n"), parse_mode: "HTML" }),
+      });
+      console.log("telegram:", r.status);
+    } catch (e) { console.log("telegram failed:", e.message); }
+  }
+
   fs.writeFileSync(".ingest/applied.json", "[]\n");
 })().catch((e) => { console.error("apply-ingest failed:", e.message); process.exit(1); });

--- a/.github/workflows/notebot-apply-ingest.yml
+++ b/.github/workflows/notebot-apply-ingest.yml
@@ -31,6 +31,8 @@ jobs:
         run: node .github/scripts/apply-ingest.js
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
       - name: Clear applied manifest
         run: |
           git config user.name "notebot-ci"


### PR DESCRIPTION
Adds a post-merge Telegram from apply-ingest reporting how many rows were inserted into the v2 notes DB (plus any new topics/subjects). Passes TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID to the apply workflow. Follow-up to #8.